### PR TITLE
Add Gilbert Point voltage

### DIFF
--- a/contents/locations/hubbard/data/timeseries.json
+++ b/contents/locations/hubbard/data/timeseries.json
@@ -102,10 +102,18 @@
     "max": 100
 },
 {
-    "name": "Voltage",
+    "name": "Voltage (Haenke)",
     "ts_codes": 18683021,
     "visible": false,
     "color": "#FA2908",
+    "units": "Volts",
+    "min": 0
+},
+{
+    "name": "Voltage (Gilbert)",
+    "ts_codes": 19072021,
+    "visible": false,
+    "color": "orange",
     "units": "Volts",
     "min": 0
 }


### PR DESCRIPTION
Includes name tags for each of the two voltages, and set the Gilbert point to an orange color.

I pushed this to the [development site](http://gadomski.github.io/glac.io/locations/hubbard/data.html), @dcfinnegan can you check and sign off? Thanks.

Fixes #137.
